### PR TITLE
Add basic login and principal pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Iniciar sesión</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="login-container">
+    <h2>Iniciar sesión</h2>
+    <form id="loginForm">
+      <label for="username">Usuario</label>
+      <input type="text" id="username" required>
+      <label for="password">Contraseña</label>
+      <input type="password" id="password" required>
+      <button type="submit">Log in</button>
+    </form>
+    <p id="error" class="error"></p>
+  </div>
+  <script src="login.js"></script>
+</body>
+</html>

--- a/login.js
+++ b/login.js
@@ -1,0 +1,10 @@
+document.getElementById('loginForm').addEventListener('submit', function (e) {
+  e.preventDefault();
+  const user = document.getElementById('username').value;
+  const pass = document.getElementById('password').value;
+  if (user === 'tako511' && pass === '123456') {
+    window.location.href = 'principal.html';
+  } else {
+    document.getElementById('error').textContent = 'Usuario o contraseña incorrectos';
+  }
+});

--- a/principal.html
+++ b/principal.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Principal</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header>
+    <h1>asistente de coordinación</h1>
+    <button id="logout">Cerrar sesión</button>
+  </header>
+  <main class="sections">
+    <section>En desarrollo</section>
+    <section>En desarrollo</section>
+    <section>En desarrollo</section>
+    <section>En desarrollo</section>
+  </main>
+  <script src="principal.js"></script>
+</body>
+</html>

--- a/principal.js
+++ b/principal.js
@@ -1,0 +1,3 @@
+document.getElementById('logout').addEventListener('click', function () {
+  window.location.href = 'index.html';
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,73 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  background: #f5f5f5;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.login-container {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  width: 300px;
+}
+
+.login-container h2 {
+  text-align: center;
+}
+
+.login-container form {
+  display: flex;
+  flex-direction: column;
+}
+
+.login-container label {
+  margin-top: 10px;
+}
+
+.login-container input {
+  padding: 8px;
+  margin-top: 5px;
+}
+
+.login-container button {
+  margin-top: 15px;
+  padding: 10px;
+}
+
+.error {
+  color: red;
+  text-align: center;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px;
+  background: #fff;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  width: 100%;
+  position: fixed;
+  top: 0;
+}
+
+.sections {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 20px;
+  padding: 100px 20px 20px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.sections section {
+  background: #fff;
+  padding: 20px;
+  border: 1px solid #ddd;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- create login screen with user/password form and styling
- add credential check for user `tako511` and redirect to principal page
- implement principal page with coordination header, logout and placeholder sections

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e6897c2d48323a442d3a1d32019f3