### PR TITLE
Center coordination headers and update logout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/index.html
+++ b/index.html
@@ -5,7 +5,8 @@
   <title>Iniciar sesión</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
+<body class="login-page">
+  <h1>Asistente de Coordinacion</h1>
   <div class="login-container">
     <h2>Iniciar sesión</h2>
     <form id="loginForm">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "proyecciondecupos",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  },
+  "license": "ISC"
+}

--- a/principal.html
+++ b/principal.html
@@ -7,8 +7,8 @@
 </head>
 <body>
   <header>
-    <h1>asistente de coordinación</h1>
-    <button id="logout">Cerrar sesión</button>
+    <h1>Asistente de Coordinacion</h1>
+    <button id="logout" class="logout-btn">Log out</button>
   </header>
   <main class="sections">
     <section>En desarrollo</section>

--- a/styles.css
+++ b/styles.css
@@ -8,6 +8,14 @@ body {
   justify-content: center;
 }
 
+body.login-page {
+  flex-direction: column;
+}
+
+body.login-page h1 {
+  text-align: center;
+}
+
 .login-container {
   background: #fff;
   padding: 20px;
@@ -54,6 +62,17 @@ header {
   width: 100%;
   position: fixed;
   top: 0;
+}
+
+header h1 {
+  flex: 1;
+  text-align: center;
+  margin: 0;
+}
+
+header .logout-btn {
+  padding: 10px 20px;
+  font-size: 16px;
 }
 
 .sections {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,9 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+
+test('index.html contains coordination header and login form', () => {
+  const html = fs.readFileSync('index.html', 'utf8');
+  assert.match(html, /<h1>Asistente de Coordinacion<\/h1>/);
+  assert.match(html, /<form id="loginForm">/);
+});

--- a/test/login.test.js
+++ b/test/login.test.js
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+function setupLoginDom() {
+  const elements = {
+    loginForm: {
+      addEventListener: (event, handler) => {
+        if (event === 'submit') elements.loginForm.submitHandler = handler;
+      }
+    },
+    username: { value: '' },
+    password: { value: '' },
+    error: { textContent: '' }
+  };
+  global.document = { getElementById: (id) => elements[id] };
+  global.window = { location: { href: '' } };
+  return elements;
+}
+
+test('redirects on correct credentials', { concurrency: false }, () => {
+  const elements = setupLoginDom();
+  delete require.cache[require.resolve('../login.js')];
+  require('../login.js');
+  elements.username.value = 'tako511';
+  elements.password.value = '123456';
+  elements.loginForm.submitHandler({ preventDefault() {} });
+  assert.strictEqual(global.window.location.href, 'principal.html');
+  delete global.document;
+  delete global.window;
+});
+
+test('shows error on incorrect credentials', { concurrency: false }, () => {
+  const elements = setupLoginDom();
+  delete require.cache[require.resolve('../login.js')];
+  require('../login.js');
+  elements.username.value = 'user';
+  elements.password.value = 'wrong';
+  elements.loginForm.submitHandler({ preventDefault() {} });
+  assert.strictEqual(elements.error.textContent, 'Usuario o contraseña incorrectos');
+  delete global.document;
+  delete global.window;
+});

--- a/test/principal-html.test.js
+++ b/test/principal-html.test.js
@@ -1,0 +1,9 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+
+test('principal.html has coordination header and logout button', () => {
+  const html = fs.readFileSync('principal.html', 'utf8');
+  assert.match(html, /<h1>Asistente de Coordinacion<\/h1>/);
+  assert.match(html, /<button id="logout"[^>]*>Log out<\/button>/);
+});

--- a/test/principal.test.js
+++ b/test/principal.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+function setupPrincipalDom() {
+  const elements = {
+    logout: {
+      addEventListener: (event, handler) => {
+        if (event === 'click') elements.logout.clickHandler = handler;
+      }
+    }
+  };
+  global.document = { getElementById: (id) => elements[id] };
+  global.window = { location: { href: 'principal.html' } };
+  return elements;
+}
+
+test('logout redirects to index.html', { concurrency: false }, () => {
+  const elements = setupPrincipalDom();
+  delete require.cache[require.resolve('../principal.js')];
+  require('../principal.js');
+  elements.logout.clickHandler();
+  assert.strictEqual(global.window.location.href, 'index.html');
+  delete global.document;
+  delete global.window;
+});


### PR DESCRIPTION
## Summary
- Centered "Asistente de Coordinacion" header on the login page
- Aligned principal header text in the center and enlarged logout button with "Log out" label
- Added tests for login and principal pages along with a Node test setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e7300f1d48323ba332c5e93e38193